### PR TITLE
Fix empty commandline

### DIFF
--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -34,7 +34,7 @@ fifc \
     -p _fifc_preview_opt \
     -o _fifc_open_opt
 fifc \
-    -n 'test -n "$fifc_desc"; and type -q -f -- "$fifc_candidate"' \
+    -n 'test \( -n "$fifc_desc" -o -z "$fifc_commandline" \); and type -q -f -- "$fifc_candidate"' \
     -r '^(?!\\w+\\h+)' \
     -p _fifc_preview_cmd \
     -o _fifc_open_cmd


### PR DESCRIPTION
Closes #3

When completing an empty commandline, there are good chance that fish output too much suggestions for passing them around, leading to errors like #3.

This PR fixes that by always piping fish completions when commandline is empty.