### PR TITLE
Various fixes

### DIFF
--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -56,13 +56,7 @@ fifc \
 
 
 # Fisher
-function _fifc_install --on-event fifc_install
-    set -U _fifc_complist_sep ' / '
-end
-
 function _fifc_uninstall --on-event fifc_uninstall
-    set -e _fifc_complist_sep
-
     for i in (seq (count $_fifc_unordered_comp))
         set -e $_fifc_unordered_comp[$i]
     end

--- a/functions/_fifc_action.fish
+++ b/functions/_fifc_action.fish
@@ -28,9 +28,7 @@ function _fifc_action
             set condition true
         end
         if test -n "$$comp[$i][2]"
-            # set -l regex (string escape --style regex $$comp[$i][2])
-            # set regex_c (string join '' "string match --regex --quiet -- '$$comp[$i][2]'" (string escape "$fifc_commandline"))
-            set regex "string match --regex --quiet -- '$$comp[$i][2]' '$fifc_commandline'"
+            set regex "string match --regex --quiet -- '$$comp[$i][2]' \"$fifc_commandline\""
         else
             set regex true
         end

--- a/functions/_fifc_completion_group.fish
+++ b/functions/_fifc_completion_group.fish
@@ -1,14 +1,15 @@
 function _fifc_completion_group -d "Determine completion group"
-    set -l path (_fifc_path_to_complete)
+    set -l path_candidate (_fifc_path_to_complete)
     # Null means that either $path is empty or is not a directory
-    set -l is_null (ls -A $path 2> /dev/null | string collect)
-    set -l parsed_complist (_fifc_parse_complist)
+    set -l is_null (ls -A $path_candidate 2> /dev/null | string collect)
+    set -l complist (_fifc_parse_complist)
 
-    if test -n "$is_null"; and ls -d -- $parsed_complist &>/dev/null
+    # When complist is big, avoid calling ls with all arguments if first is neither a file nor a directory
+    if test -n "$is_null"; and test \( -f "$complist[1]" -o -d "$complist[1]" \); and echo (string escape -- $complist) | xargs ls -d -- &>/dev/null
         echo files
     else if string match --regex --quiet -- '\h+\-+\h*$' $fifc_commandline
         echo options
-    else if _fifc_parse_complist | string join '' | string match --regex --quiet '^[0-9]+$'
+    else if string join -- '' (string escape -- $complist) | string match --regex --quiet '^[0-9]+$'
         echo processes
     end
 end

--- a/functions/_fifc_parse_complist.fish
+++ b/functions/_fifc_parse_complist.fish
@@ -1,5 +1,5 @@
 function _fifc_parse_complist -d "Extract the first column of fish completion list"
-    _fifc_split_complist \
+    cat $_fifc_complist_path \
         | string unescape \
         | uniq \
         | awk -F '\t' '{ print $1 }'

--- a/functions/_fifc_path_to_complete.fish
+++ b/functions/_fifc_path_to_complete.fish
@@ -1,6 +1,7 @@
 function _fifc_path_to_complete
-    if string match --regex --quiet -- '.*(\w|\.|/)+$' "$fifc_token"
-        echo "$fifc_token"
+    set -l token (string unescape $fifc_token)
+    if string match --regex --quiet -- '.*(\w|\.|/)+$' "$token"
+        echo "$token"
     else
         echo {$PWD}/
     end

--- a/functions/_fifc_source_files.fish
+++ b/functions/_fifc_source_files.fish
@@ -1,5 +1,5 @@
 function _fifc_source_files -d "Return a command to recursively find files"
-    set -l path (_fifc_path_to_complete)
+    set -l path (_fifc_path_to_complete | string escape)
     set -l hidden (string match "*." "$path")
 
     if type -q fd

--- a/functions/_fifc_split_complist.fish
+++ b/functions/_fifc_split_complist.fish
@@ -1,3 +1,0 @@
-function _fifc_split_complist -d "Split completion list"
-    string split -- $_fifc_complist_sep $_fifc_complist
-end

--- a/tests/exposed_vars.fish
+++ b/tests/exposed_vars.fish
@@ -1,16 +1,11 @@
 set curr_fifc_unordered_comp $_fifc_unordered_comp
 set dir "tests/_resources/dir with spaces"
+set _fifc_complist_path (mktemp)
 
 function _fifc_test_exposed_vars
     switch $var
         case candidate
             echo -n "$fifc_candidate"
-        case group
-            echo -n "$fifc_group"
-        case token
-            echo -n "$fifc_token"
-        case commandline
-            echo -n "$fifc_commandline"
         case extracted
             echo -n "$fifc_extracted"
     end
@@ -32,13 +27,10 @@ set var candidate
 set actual (_fifc_action "preview" "$dir/file 1.txt")
 @test "exposed vars fifc_candidate" "$actual" = "$dir/file 1.txt"
 
-set var group
-set _fifc_complist (string join $_fifc_complist_sep "$dir/file 1.txt" "$dir/file 2.txt")
-set actual (_fifc_action "preview" "$dir/file 1.txt")
-@test "exposed vars fifc_group" "$actual" = files
-
 set var extracted
 set -x fifc_extracted
 set _fifc_extract_regex '.*/(.*\.txt)$'
 set actual (_fifc_action "preview" "$dir/file 1.txt")
 @test "exposed vars fifc_extracted" "$actual" = "file 1.txt"
+
+rm $_fifc_complist_path

--- a/tests/group.fish
+++ b/tests/group.fish
@@ -1,21 +1,23 @@
+set _fifc_complist_path (mktemp)
 
 set _commandline "kill "
-set _fifc_complist (complete -C --escape -- "$_commandline")
+complete -C --escape -- "$_commandline" >$_fifc_complist_path
 set fifc_commandline "$_commandline"
 set actual (_fifc_completion_group)
 @test "group test pid" "$actual" = processes
 
-set _commandline "ls tests/_resources/dir with spaces/"
-set _fifc_complist (complete -C --escape -- "$_commandline")
+set _commandline "ls tests/_resources/dir\ with\ spaces/"
+complete -C --escape -- "$_commandline" >$_fifc_complist_path
 set fifc_commandline "$_commandline"
 set actual (_fifc_completion_group)
 @test "group test files" "$actual" = files
 
 set _commandline "ls -"
-set _fifc_complist (complete -C --escape -- "$_commandline")
+complete -C --escape -- "$_commandline" >$_fifc_complist_path
 set fifc_commandline "$_commandline"
 set actual (_fifc_completion_group)
 @test "group test options" "$actual" = options
 
 set -e _fifc_complist
 set -e fifc_commandline
+rm $_fifc_complist_path

--- a/tests/match_order.fish
+++ b/tests/match_order.fish
@@ -1,6 +1,7 @@
 set curr_fifc_unordered_comp $_fifc_unordered_comp
 set curr_fifc_ordered_comp $_fifc_ordered_comp
 set dir "tests/_resources/dir with spaces"
+set _fifc_complist_path (mktemp)
 
 # Add unordered completions
 set comp_1 \
@@ -31,7 +32,7 @@ set fifc_commandline "ls "
 set actual (_fifc_action "preview" "$dir")
 @test "preview match condition and regex second completion" "$actual" = comp_2
 
-set _fifc_complist "fallback    description"
+echo "fallback    description" >$_fifc_complist_path
 set fifc_commandline "fallback "
 set actual (_fifc_action "preview" 'fallback')
 @test "preview fallback fish description" "$actual" = description
@@ -54,3 +55,4 @@ set actual (_fifc_action "preview" "$dir/file 1.txt")
 set -e fifc_commandline
 set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
 set -gx _fifc_ordered_comp $curr_fifc_ordered_comp
+rm $_fifc_complist_path

--- a/tests/source.fish
+++ b/tests/source.fish
@@ -1,5 +1,6 @@
 set curr_fifc_unordered_comp $_fifc_unordered_comp
 set curr_fifc_ordered_comp $_fifc_ordered_comp
+set _fifc_complist_path (mktemp)
 
 # Add unordered sources
 set comp_1 'test "$any" = "1"' '^kill $' '' '' 'echo comp_1'
@@ -23,3 +24,4 @@ set actual (_fifc_action "source")
 set -e fifc_commandline
 set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
 set -gx _fifc_unordered_comp $curr_fifc_ordered_comp
+rm $_fifc_complist_path


### PR DESCRIPTION
Closes #6

- Fish complist is now stored in a temporary file to avoid exceeding os arg length
- Fix a bug when completing path with spaces 