### PR TITLE
WIP: setup fifc only on an interactive shell

### DIFF
--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -1,59 +1,60 @@
-# Keybindings
-for mode in default insert
-    if not set --query --universal fifc_keybinding
-        bind --mode $mode \t _fifc
-    else
-        bind --mode $mode $fifc_keybinding _fifc
+if status is-interactive
+    # Keybindings
+    for mode in default insert
+        if not set --query --universal fifc_keybinding
+            bind --mode $mode \t _fifc
+        else
+            bind --mode $mode $fifc_keybinding _fifc
+        end
     end
+
+    if not set --query --universal fifc_open_keybinding
+        set --universal fifc_open_keybinding ctrl-o
+    end
+
+
+    # Private
+    set -Ux _fifc_comp_count 0
+    set -gx _fifc_unordered_comp
+    set -gx _fifc_ordered_comp
+
+    # Set sources
+    fifc \
+        -n 'test "$fifc_group" = "files"' \
+        -s _fifc_source_files
+    fifc \
+        -n 'test "$fifc_group" = processes' \
+        -s 'ps --no-headers -ax --format pid,command'
+
+    # Builtin preview/open commands
+    fifc \
+        -n 'test "$fifc_group" = "options"' \
+        -p _fifc_preview_opt \
+        -o _fifc_open_opt
+    fifc \
+        -n 'test \( -n "$fifc_desc" -o -z "$fifc_commandline" \); and type -q -f -- "$fifc_candidate"' \
+        -r '^(?!\\w+\\h+)' \
+        -p _fifc_preview_cmd \
+        -o _fifc_open_cmd
+    fifc \
+        -n 'test -n "$fifc_desc" -o -z "$fifc_commandline"' \
+        -r '^(functions)?\\h+' \
+        -p _fifc_preview_fn \
+        -o _fifc_open_fn
+    fifc \
+        -n 'test -f "$fifc_candidate"' \
+        -p _fifc_preview_file \
+        -o _fifc_open_file
+    fifc \
+        -n 'test -d "$fifc_candidate"' \
+        -p _fifc_preview_dir \
+        -o _fifc_open_dir
+    fifc \
+        -n 'test "$fifc_group" = processes -a (ps -p (_fifc_parse_pid "$fifc_candidate") &>/dev/null)' \
+        -p _fifc_preview_process \
+        -o _fifc_open_process \
+        -e '^\\h*([0-9]+)'
 end
-
-if not set --query --universal fifc_open_keybinding
-    set --universal fifc_open_keybinding ctrl-o
-end
-
-
-# Private
-set -Ux _fifc_comp_count 0
-set -gx _fifc_unordered_comp
-set -gx _fifc_ordered_comp
-
-# Set sources
-fifc \
-    -n 'test "$fifc_group" = "files"' \
-    -s _fifc_source_files
-fifc \
-    -n 'test "$fifc_group" = processes' \
-    -s 'ps --no-headers -ax --format pid,command'
-
-# Builtin preview/open commands
-fifc \
-    -n 'test "$fifc_group" = "options"' \
-    -p _fifc_preview_opt \
-    -o _fifc_open_opt
-fifc \
-    -n 'test \( -n "$fifc_desc" -o -z "$fifc_commandline" \); and type -q -f -- "$fifc_candidate"' \
-    -r '^(?!\\w+\\h+)' \
-    -p _fifc_preview_cmd \
-    -o _fifc_open_cmd
-fifc \
-    -n 'test -n "$fifc_desc" -o -z "$fifc_commandline"' \
-    -r '^(functions)?\\h+' \
-    -p _fifc_preview_fn \
-    -o _fifc_open_fn
-fifc \
-    -n 'test -f "$fifc_candidate"' \
-    -p _fifc_preview_file \
-    -o _fifc_open_file
-fifc \
-    -n 'test -d "$fifc_candidate"' \
-    -p _fifc_preview_dir \
-    -o _fifc_open_dir
-fifc \
-    -n 'test "$fifc_group" = processes -a (ps -p (_fifc_parse_pid "$fifc_candidate") &>/dev/null)' \
-    -p _fifc_preview_process \
-    -o _fifc_open_process \
-    -e '^\\h*([0-9]+)'
-
 
 # Fisher
 function _fifc_uninstall --on-event fifc_uninstall


### PR DESCRIPTION
Hey @gazorby,

thanks for your work on this plugin. I've been toying around with it for the last few days and am liking it so far!

I had one issue where it interferes with my neovim configuration though in an unexpected way.
I'm using [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) which launches commands in a subshell to identify git directories. Instead of getting a result it seemed to be stuck in a loop and retrying indefinately.

I tracked it down to the fifc command, specifically this block of variable setup:
https://github.com/gazorby/fifc/blob/main/functions/fifc.fish#L39-L48

These changes are just a quick workaround for myself. But as tab completion is an interactive feature in itself it might make sense nonetheless. :-)

Best regards!