### PR TITLE
feat: add fzf-tmux support

### DIFF
--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -1,4 +1,6 @@
 function _fifc
+    set -l std_cmd "fzf -d \t"
+    set -l new_cmd $fifc_fzf_cmd
     set -l result
     set -Ux _fifc_extract_regex
     set -gx _fifc_complist_path (string join '' (mktemp) "_fifc")
@@ -26,10 +28,7 @@ function _fifc
 
     set fifc_fzf_query (string trim --chars '\'' -- "$fifc_fzf_query")
 
-    set -l fzf_cmd "
-        fzf \
-            -d \t \
-            --exact \
+    set -l fzf_opts "--exact \
             --tiebreak=length \
             --select-1 \
             --exit-0 \
@@ -42,6 +41,12 @@ function _fifc
             --bind='$fifc_open_keybinding:execute(_fifc_action open {} {q} &> /dev/tty)' \
             --query '$fifc_query' \
             $_fifc_custom_fzf_opts"
+
+    if test -n "$new_cmd"
+        set fzf_cmd (string join -- " " $new_cmd $fzf_opts)
+    else
+        set fzf_cmd (string join -- " " $std_cmd $fzf_opts)
+    end
 
     set -l cmd (string join -- " | " $source_cmd $fzf_cmd)
     # We use eval hack because wrapping source command


### PR DESCRIPTION
hey,

thank you for making such a great tool.
this is my first pull request ever, so please be gentle.

fzf ships with with a [wrapper-script](https://github.com/junegunn/fzf?tab=readme-ov-file#fzf-tmux-script) for tmux integration.
`fzf-tmux -p` opens a popup windows in tmux. 
i added the ability to define your own "fzf command"
when you set the variable `fifc_fzf_cmd` to `"fzf-tmux -p 80%,60%"` for example like:
`set -Ux fifc_fzf_cmd "fzf-tmux -p 80%,60%"`
the completion interface will be shown in a popup window.

![fifc_popup](https://github.com/gazorby/fifc/assets/104655548/319c676d-a37b-40d3-9481-2c4571ea16d1)


this is my first ever contribution to an open source project and i really suck at variable names... =]
i didn't want to mess with your readme for my little change.

i'd like to hear some criticism, got a lot to learn.

cheers