### PR TITLE
fix: don't escape environment variable in completion

### DIFF
--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -47,10 +47,11 @@ function _fifc
     # We use eval hack because wrapping source command
     # inside a function cause some delay before fzf to show up
     eval $cmd | while read -l token
-        # string escape will escape '~' if present (at the begenning of path).
-        # so we need to exclude it from escaping
+        # don't escape '~' for path, `$` for environ
         if string match --quiet '~*' -- $token
             set -a result (string join -- "" "~" (string sub --start 2 -- $token | string escape))
+        else if string match --quiet '$*' -- $token
+            set -a result (string join -- "" "\$" (string sub --start 2 -- $token | string escape))
         else
             set -a result (string escape --no-quoted -- $token)
         end


### PR DESCRIPTION
Fix a bug: environment varibles completion like `$HOME` will be mistakenly escaped as `\$HOME`.
