### PR TITLE
perf(startup): skip load of fifc rules when in interactive shell

### DIFF
--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -1,62 +1,63 @@
-# Keybindings
-for mode in default insert
-    if not set --query --universal fifc_keybinding
+if status is-interactive
+    # Keybindings
+    set -qU fifc_keybinding
+    or set -U fifc_keybinding \t
+
+    set -qU fifc_open_keybinding
+    or set -U fifc_open_keybinding ctrl-o
+
+    for mode in default insert
         bind --mode $mode \t _fifc
-    else
         bind --mode $mode $fifc_keybinding _fifc
     end
+
+    # Only load fifc rules when fish is launched fzf
+else if set -q _fifc_launched_by_fzf
+    # Private
+    set -gx _fifc_comp_count 0
+    set -gx _fifc_unordered_comp
+    set -gx _fifc_ordered_comp
+
+    # Set sources
+    fifc \
+        -n 'test "$fifc_group" = "directories"' \
+        -s _fifc_source_directories
+    fifc \
+        -n 'test "$fifc_group" = "files"' \
+        -s _fifc_source_files
+    fifc \
+        -n 'test "$fifc_group" = processes' \
+        -s 'ps -ax -o pid=,command='
+
+    # Builtin preview/open commands
+    fifc \
+        -n 'test "$fifc_group" = "options"' \
+        -p _fifc_preview_opt \
+        -o _fifc_open_opt
+    fifc \
+        -n 'test \( -n "$fifc_desc" -o -z "$fifc_commandline" \); and type -q -f -- "$fifc_candidate"' \
+        -r '^(?!\\w+\\h+)' \
+        -p _fifc_preview_cmd \
+        -o _fifc_open_cmd
+    fifc \
+        -n 'test -n "$fifc_desc" -o -z "$fifc_commandline"' \
+        -r '^(functions)?\\h+' \
+        -p _fifc_preview_fn \
+        -o _fifc_open_fn
+    fifc \
+        -n 'test -f "$fifc_candidate"' \
+        -p _fifc_preview_file \
+        -o _fifc_open_file
+    fifc \
+        -n 'test -d "$fifc_candidate"' \
+        -p _fifc_preview_dir \
+        -o _fifc_open_dir
+    fifc \
+        -n 'test "$fifc_group" = processes -a (ps -p (_fifc_parse_pid "$fifc_candidate") &>/dev/null)' \
+        -p _fifc_preview_process \
+        -o _fifc_open_process \
+        -e '^\\h*([0-9]+)'
 end
-
-if not set --query --universal fifc_open_keybinding
-    set --universal fifc_open_keybinding ctrl-o
-end
-
-
-# Private
-set -gx _fifc_comp_count 0
-set -gx _fifc_unordered_comp
-set -gx _fifc_ordered_comp
-
-# Set sources
-fifc \
-    -n 'test "$fifc_group" = "directories"' \
-    -s _fifc_source_directories
-fifc \
-    -n 'test "$fifc_group" = "files"' \
-    -s _fifc_source_files
-fifc \
-    -n 'test "$fifc_group" = processes' \
-    -s 'ps -ax -o pid=,command='
-
-# Builtin preview/open commands
-fifc \
-    -n 'test "$fifc_group" = "options"' \
-    -p _fifc_preview_opt \
-    -o _fifc_open_opt
-fifc \
-    -n 'test \( -n "$fifc_desc" -o -z "$fifc_commandline" \); and type -q -f -- "$fifc_candidate"' \
-    -r '^(?!\\w+\\h+)' \
-    -p _fifc_preview_cmd \
-    -o _fifc_open_cmd
-fifc \
-    -n 'test -n "$fifc_desc" -o -z "$fifc_commandline"' \
-    -r '^(functions)?\\h+' \
-    -p _fifc_preview_fn \
-    -o _fifc_open_fn
-fifc \
-    -n 'test -f "$fifc_candidate"' \
-    -p _fifc_preview_file \
-    -o _fifc_open_file
-fifc \
-    -n 'test -d "$fifc_candidate"' \
-    -p _fifc_preview_dir \
-    -o _fifc_open_dir
-fifc \
-    -n 'test "$fifc_group" = processes -a (ps -p (_fifc_parse_pid "$fifc_candidate") &>/dev/null)' \
-    -p _fifc_preview_process \
-    -o _fifc_open_process \
-    -e '^\\h*([0-9]+)'
-
 
 # Fisher
 function _fifc_uninstall --on-event fifc_uninstall

--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -61,16 +61,4 @@ end
 
 # Fisher
 function _fifc_uninstall --on-event fifc_uninstall
-    for i in (seq (count $_fifc_unordered_comp))
-        set -e $_fifc_unordered_comp[$i]
-    end
-
-    for i in (seq (count $_fifc_ordered_comp))
-        set -e $_fifc_ordered_comp[$i]
-    end
-
-    set -e _fifc_comp_count
-    set -e _fifc_source_count
-    set -e _fifc_unordered_comp
-    set -e _fifc_ordered_comp
 end

--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -27,7 +27,7 @@ function _fifc
     set fifc_fzf_query (string trim --chars '\'' -- "$fifc_fzf_query")
 
     set -l fzf_cmd "
-        fzf \
+        _fifc_launched_by_fzf=1 SHELL=fish fzf \
             -d \t \
             --exact \
             --tiebreak=length \


### PR DESCRIPTION
I notice taht "fifc rules" is only intended to be used in a interative fish shell spawn by fzf (by `$SHELL -c`).
So I tweak the startup process so that we can conditional skip it.

This pr can also fix https://github.com/gazorby/fifc/issues/31 in a more direct way.
