### PR TITLE
Allow override of rm and custom fzf options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ By default fifc override `tab`, but you can assign another keybinding:
 set -U fifc_keybinding \cx
 ```
 
+fifc will also by default use `rm` to remove temporary files, this can changed:
+
+```fish
+# Use trash instead of rm
+set -U fifc_rm_cmd trash
+```
+
+To append a custom fzf command, for example to disable the `--exact` flag and increase the fuzziness:
+
+```fish
+set -U fifc_custom_fzf_opts +e
+```
+
 fifc can use modern tools if available:
 
 | Prefer                                           | Fallback to | Used for                                  | Custom options     |

--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -6,8 +6,13 @@ if status is-interactive
     set -qU fifc_open_keybinding
     or set -U fifc_open_keybinding ctrl-o
 
+    set -qU fifc_rm_cmd
+    or set -U fifc_rm_cmd rm
+
+    set -qU fifc_custom_fzf_opts
+    or set -U fifc_custom_fzf_opts
+
     for mode in default insert
-        bind --mode $mode \t _fifc
         bind --mode $mode $fifc_keybinding _fifc
     end
 

--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -3,7 +3,6 @@ function _fifc
     set -l result
     set -Ux _fifc_extract_regex
     set -gx _fifc_complist_path (string join '' (mktemp) "_fifc")
-    set -gx _fifc_custom_fzf_opts
     set -gx fifc_extracted
     set -gx fifc_commandline
     set -gx fifc_token (commandline --current-token)
@@ -42,7 +41,7 @@ function _fifc
             --preview '_fifc_action preview {} {q}' \
             --bind='$fifc_open_keybinding:execute(_fifc_action open {} {q} &> /dev/tty)' \
             --query '$fifc_query' \
-            $_fifc_custom_fzf_opts"
+            $fifc_custom_fzf_opts"
 
     set -l cmd (string join -- " | " $source_cmd $fzf_cmd)
     # We use eval hack because wrapping source command
@@ -79,10 +78,9 @@ function _fifc
 
     commandline --function repaint
 
-    rm $_fifc_complist_path
+    command $fifc_rm_cmd $_fifc_complist_path
     # Clean state
     set -e _fifc_extract_regex
-    set -e _fifc_custom_fzf_opts
     set -e _fifc_complist_path
     set -e fifc_token
     set -e fifc_group

--- a/functions/_fifc_action.fish
+++ b/functions/_fifc_action.fish
@@ -53,7 +53,6 @@ function _fifc_action
             eval $$comp[$i][4]
             break
         else if test "$action" = source; and test -n "$$comp[$i][5]"
-            set fifc_custom_fzf_opts "$$comp[$i][6]"
             if functions "$$comp[$i][5]" 1>/dev/null
                 eval $$comp[$i][5]
             else

--- a/functions/_fifc_action.fish
+++ b/functions/_fifc_action.fish
@@ -53,7 +53,7 @@ function _fifc_action
             eval $$comp[$i][4]
             break
         else if test "$action" = source; and test -n "$$comp[$i][5]"
-            set _fifc_custom_fzf_opts "$$comp[$i][6]"
+            set fifc_custom_fzf_opts "$$comp[$i][6]"
             if functions "$$comp[$i][5]" 1>/dev/null
                 eval $$comp[$i][5]
             else

--- a/tests/test_exposed_vars.fish
+++ b/tests/test_exposed_vars.fish
@@ -40,4 +40,4 @@ set -x fifc_query
 set actual (_fifc_action "preview" "$dir/file 1.txt" "1")
 @test "exposed vars fifc_query" "$actual" = 1
 
-rm $_fifc_complist_path
+command $fifc_rm_cmd $_fifc_complist_path

--- a/tests/test_group.fish
+++ b/tests/test_group.fish
@@ -20,4 +20,4 @@ set actual (_fifc_completion_group)
 
 set -e _fifc_complist
 set -e fifc_commandline
-rm $_fifc_complist_path
+command $fifc_rm_cmd $_fifc_complist_path

--- a/tests/test_match_order.fish
+++ b/tests/test_match_order.fish
@@ -55,4 +55,4 @@ set actual (_fifc_action "preview" "$dir/file 1.txt")
 set -e fifc_commandline
 set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
 set -gx _fifc_ordered_comp $curr_fifc_ordered_comp
-rm $_fifc_complist_path
+command $fifc_rm_cmd $_fifc_complist_path

--- a/tests/test_source.fish
+++ b/tests/test_source.fish
@@ -24,4 +24,4 @@ set actual (_fifc_action "source")
 set -e fifc_commandline
 set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
 set -gx _fifc_unordered_comp $curr_fifc_ordered_comp
-rm $_fifc_complist_path
+command $fifc_rm_cmd $_fifc_complist_path


### PR DESCRIPTION
It's not unusual to alias `rm` to something harmless when using, for example, trash to remove files/directories. This PR will enable the user to change that command. This PR also lets the user add additional argument to the fzf_cmd, something that was not working properly before (I believe?)