### PR TITLE
Make directory completions respect `fifc_fd_opts`

### DIFF
--- a/functions/_fifc_source_directories.fish
+++ b/functions/_fifc_source_directories.fish
@@ -1,9 +1,9 @@
 function _fifc_source_directories -d "Return a command to recursively find directories"
     if type -q fd
-        set --local --export fifc_fd_opts -t d
+        set --local --export --append fifc_fd_opts -t d
         _fifc_source_files
     else
-        set --local --export fifc_find_opts -type d
+        set --local --export --append fifc_find_opts -type d
         _fifc_source_files
     end
 end


### PR DESCRIPTION
Currently `fifc_fd_opts` is ignored when completing directories as the variable is overwritten with `set --local --export fifc_fd_opts -t d`. Adding `--append` option to `set` will resolve this.