### PR TITLE
Fix escaping fzf query

### DIFF
--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -25,7 +25,7 @@ function _fifc
     set -gx fifc_group (_fifc_completion_group)
     set source_cmd (_fifc_action source)
 
-    set fifc_fzf_query (string trim --chars '\'' -- "$fifc_fzf_query")
+    set fifc_safe_query (string unescape -- "$fifc_query")
 
     set -l fzf_cmd "
         _fifc_launched_by_fzf=1 SHELL=fish fzf \
@@ -41,7 +41,7 @@ function _fifc
             --header '$header' \
             --preview '_fifc_action preview {} {q}' \
             --bind='$fifc_open_keybinding:execute(_fifc_action open {} {q} &> /dev/tty)' \
-            --query '$fifc_query' \
+            --query '$fifc_safe_query' \
             $_fifc_custom_fzf_opts"
 
     set -l cmd (string join -- " | " $source_cmd $fzf_cmd)


### PR DESCRIPTION
I noticed that when trying to get fzf completion for directories that had backslashes to escape characters, it wouldn't work.
`string trim` only removes the backslashes from the beginning and the end of the string, not the middle (which it didn't even do because the correct syntax is `'\\'`, not `'\''`).

Fish has the command `string unescape`, seems to be the correct one for this context.

In commit cfe17fb, the variable `fifc_fzf_query` changes to `fifc_query` in its declaration and in `fzf_cmd`, but not in this line: https://github.com/gazorby/fifc/blob/cfe17fbe562bdf4a5318516de8573fd55818be36/functions/_fifc.fish#L29
which means the trim stopped applying.