### PR TITLE
fix: remove extra tab binding

### DIFF
--- a/conf.d/fifc.fish
+++ b/conf.d/fifc.fish
@@ -12,7 +12,6 @@ if status is-interactive
     or set -U fifc_open_keybinding ctrl-o
 
     for mode in default insert
-        bind --mode $mode \t _fifc
         bind --mode $mode $fifc_keybinding _fifc
     end
 


### PR DESCRIPTION
Currently the logic for setting the `fifc_keybinding` always binds the Tab alongside what the user has configured. This does not seem necessary, since the code above the bind takes care of setting `fifc_keybinding` to a default value, so a single bind should be enough and allow for a user override.
https://github.com/gazorby/fifc/blob/a01650cd432becdc6e36feeff5e8d657bd7ee84a/conf.d/fifc.fish#L6-L17
Looking at the code this seems to be a regression from 64433fa58b7d102f18eb2160d52ef706296cb585. It looks like this worked previously.
Unless there is a reason for keeping it this way, this PR should restore the functionality, by removing the extraneous bind.