### PR TITLE
Force-remove temp completion file to coexist with `alias rm='rm -i'`

### DIFF
--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -79,7 +79,7 @@ function _fifc
 
     commandline --function repaint
 
-    rm $_fifc_complist_path
+    rm -f $_fifc_complist_path
     # Clean state
     set -e _fifc_extract_regex
     set -e _fifc_custom_fzf_opts


### PR DESCRIPTION
## Summary

`_fifc` removes the temporary completion-list file (created via `mktemp`) at the end of each invocation using a plain `rm $_fifc_complist_path`. For users who alias `rm` to `rm -i` — a common safety habit — that alias injects an interactive confirmation prompt on every completion, breaking the flow.

This change switches that single call to `rm -f`, which:

- Bypasses the `-i` confirmation an alias would inject.
- Silently no-ops if the file is already gone, which is harmless here since the path is only used by `_fifc` itself.

Scope is intentionally minimal: only the cleanup of `$_fifc_complist_path` in `functions/_fifc.fish` is touched. No behavior change for users without the alias.

## Test plan

- [ ] With `alias rm='rm -i'` set in fish, trigger fifc completion and confirm no confirmation prompt appears and the temp file is removed.
- [ ] Without the alias, confirm behavior is unchanged.