### PR TITLE
fix: Fixes for paths that start with `~`

### DIFF
--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -52,9 +52,9 @@ function _fifc
     eval $cmd | while read -l token
         # don't escape '~' for path, `$` for environ
         if string match --quiet '~*' -- $token
-            set -a result (string join -- "" "~" (string sub --start 2 -- $token | string escape))
+            set -a result (string join -- "" "~" (string sub --start 2 -- $token | string escape --no-quoted))
         else if string match --quiet '$*' -- $token
-            set -a result (string join -- "" "\$" (string sub --start 2 -- $token | string escape))
+            set -a result (string join -- "" "\$" (string sub --start 2 -- $token | string escape --no-quoted))
         else
             set -a result (string escape --no-quoted -- $token)
         end

--- a/functions/_fifc.fish
+++ b/functions/_fifc.fish
@@ -67,8 +67,9 @@ function _fifc
     # Add space trailing space only if:
     # - there is no trailing space already present
     # - Result is not a directory
-    # We need to unescape $result for directory test as we escaped it before
-    if test (count $result) -eq 1; and not test -d (string unescape -- $result[1])
+    # Expand tilde before directory test since fish doesn't expand ~ from variables
+    set -l result_path (_fifc_expand_tilde (string unescape -- $result[1]))
+    if test (count $result) -eq 1; and not test -d "$result_path"
         set -l buffer (string split -- "$fifc_commandline" (commandline -b))
         if not string match -- ' *' "$buffer[2]"
             set -a result ''

--- a/functions/_fifc_action.fish
+++ b/functions/_fifc_action.fish
@@ -8,7 +8,8 @@ function _fifc_action
 
     # Variables exposed to evaluated commands
     set -x fifc_desc (sed -nr (printf 's/^%s[[:blank:]]+(.*)/\\\1/p' "$regex_val") $_fifc_complist_path | string trim)
-    set -x fifc_candidate "$argv[2]"
+    # Expand ~ to $HOME so test -f/d and preview commands work with variable values
+    set -x fifc_candidate (_fifc_expand_tilde "$argv[2]")
     set -x fifc_extracted (string match --regex --groups-only -- "$_fifc_extract_regex" "$argv[2]")
 
     if test "$action" = preview

--- a/functions/_fifc_expand_tilde.fish
+++ b/functions/_fifc_expand_tilde.fish
@@ -1,3 +1,3 @@
 function _fifc_expand_tilde
-    string replace --regex -- '^~' "$HOME" $argv
+    string replace --regex -- '^~(?=/|$)' "$HOME" $argv
 end

--- a/functions/_fifc_source_files.fish
+++ b/functions/_fifc_source_files.fish
@@ -3,6 +3,11 @@ function _fifc_source_files -d "Return a command to recursively find files"
     set -l escaped_path (string escape -- $raw_path)
     set -l hidden (string match "*." "$raw_path")
 
+    # Build anchored regex to convert $HOME back to ~ in output
+    # Accounts for optional ANSI color codes from fd --color=always
+    set -l escaped_home (string escape --style=regex -- "$HOME")
+    set -l home_re "^(\x1b\[[0-9;]*m)*$escaped_home"
+
     if string match --quiet -- '~*' "$fifc_query"
         set -e fifc_query
     end
@@ -17,15 +22,15 @@ function _fifc_source_files -d "Return a command to recursively find files"
         else if test "$raw_path" = "."
             echo "fd . $fifc_fd_opts --color=always --hidden $fd_custom_opts"
         else if test -n "$hidden"
-            echo "fd . $fifc_fd_opts --color=always --hidden -- $escaped_path"
+            echo "fd . $fifc_fd_opts --color=always --hidden -- $escaped_path | string replace --regex -- \"$home_re\" '~'"
         else
-            echo "fd . $fifc_fd_opts --color=always -- $escaped_path"
+            echo "fd . $fifc_fd_opts --color=always -- $escaped_path | string replace --regex -- \"$home_re\" '~'"
         end
     else if test -n "$hidden"
         # Use sed to strip cwd prefix
-        echo "find . $escaped_path $fifc_find_opts ! -path . -print 2>/dev/null | sed 's|^\./||'"
+        echo "find . $escaped_path $fifc_find_opts ! -path . -print 2>/dev/null | sed 's|^\./||' | string replace --regex -- \"$home_re\" '~'"
     else
         # Exclude hidden directories
-        echo "find . $escaped_path $fifc_find_opts ! -path . ! -path '*/.*' -print 2>/dev/null | sed 's|^\./||'"
+        echo "find . $escaped_path $fifc_find_opts ! -path . ! -path '*/.*' -print 2>/dev/null | sed 's|^\./||' | string replace --regex -- \"$home_re\" '~'"
     end
 end

--- a/functions/_fifc_source_files.fish
+++ b/functions/_fifc_source_files.fish
@@ -8,10 +8,6 @@ function _fifc_source_files -d "Return a command to recursively find files"
     set -l escaped_home (string escape --style=regex -- "$HOME")
     set -l home_re "^(\x1b\[[0-9;]*m)*$escaped_home"
 
-    if string match --quiet -- '~*' "$fifc_query"
-        set -e fifc_query
-    end
-
     if type -q fd
         if _fifc_test_version (fd --version) -ge "8.3.0"
             set fd_custom_opts --strip-cwd-prefix

--- a/tests/test_expand_tilde.fish
+++ b/tests/test_expand_tilde.fish
@@ -1,0 +1,10 @@
+set curr_home $HOME
+set -gx HOME /home/test-user
+
+set actual (_fifc_expand_tilde '~/downloads')
+@test "expand current user tilde path" "$actual" = /home/test-user/downloads
+
+set actual (_fifc_expand_tilde '~otheruser/downloads')
+@test "do not expand other user tilde path" "$actual" = '~otheruser/downloads'
+
+set -gx HOME $curr_home

--- a/tests/test_fifc_tilde.fish
+++ b/tests/test_fifc_tilde.fish
@@ -1,0 +1,47 @@
+set curr_home $HOME
+set curr_fifc_unordered_comp $_fifc_unordered_comp
+set curr_fifc_ordered_comp $_fifc_ordered_comp
+
+set test_home (mktemp -d)
+set -gx HOME "$test_home"
+mkdir -p "$HOME/downloads"
+
+set test_fifc_token '~/downl'
+set test_fzf_selection '~/downloads/'
+set test_replaced_token
+
+function commandline
+    switch $argv[1]
+        case --current-token
+            echo $test_fifc_token
+        case --cut-at-cursor
+            echo "ls $test_fifc_token"
+        case -b
+            echo "ls $test_fifc_token"
+        case --replace
+            set -g test_replaced_token $argv[-1]
+        case --function
+            return 0
+    end
+end
+
+function complete
+end
+
+function fzf
+    echo $test_fzf_selection
+end
+
+set fifc_rm_cmd rm
+set _fifc_ordered_comp
+set comp_1 true '' '' '' 'printf "%s\n" candidate'
+set _fifc_unordered_comp comp_1
+
+_fifc
+
+@test "fifc does not add trailing space after tilde directory" "$test_replaced_token" = '~/downloads/'
+
+command rm -rf "$test_home"
+set -gx HOME "$curr_home"
+set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
+set -gx _fifc_ordered_comp $curr_fifc_ordered_comp

--- a/tests/test_fifc_tilde.fish
+++ b/tests/test_fifc_tilde.fish
@@ -45,3 +45,52 @@ command rm -rf "$test_home"
 set -gx HOME "$curr_home"
 set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
 set -gx _fifc_ordered_comp $curr_fifc_ordered_comp
+
+set curr_home $HOME
+set curr_fifc_unordered_comp $_fifc_unordered_comp
+set curr_fifc_ordered_comp $_fifc_ordered_comp
+
+set test_home (mktemp -d)
+set -gx HOME "$test_home"
+mkdir -p "$HOME/downloads"
+touch "$HOME/downloads/test test.txt"
+
+set test_fifc_token '~/downloads/test'
+set test_fzf_selection '~/downloads/test test.txt'
+set test_replaced_token
+
+function commandline
+    switch $argv[1]
+        case --current-token
+            echo $test_fifc_token
+        case --cut-at-cursor
+            echo "ls $test_fifc_token"
+        case -b
+            echo "ls $test_fifc_token"
+        case --replace
+            set -g test_replaced_token $argv[-1]
+        case --function
+            return 0
+    end
+end
+
+function complete
+end
+
+function fzf
+    echo $test_fzf_selection
+end
+
+set fifc_rm_cmd rm
+set _fifc_ordered_comp
+set comp_1 true '' '' '' 'printf "%s\n" candidate'
+set _fifc_unordered_comp comp_1
+
+_fifc
+
+@test "fifc escapes spaces in tilde file without quotes" "$test_replaced_token" = '~/downloads/test\ test.txt '
+
+command rm -rf "$test_home"
+set -gx HOME "$curr_home"
+set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
+set -gx _fifc_ordered_comp $curr_fifc_ordered_comp

--- a/tests/test_fzf_query.fish
+++ b/tests/test_fzf_query.fish
@@ -50,3 +50,62 @@ set actual (_test_fzf_query "tests/_resources/dir\\'apostrophe/")
 command rm $test_fzf_argv_path
 set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
 set -gx _fifc_ordered_comp $curr_fifc_ordered_comp
+
+set curr_home $HOME
+set curr_fifc_unordered_comp $_fifc_unordered_comp
+set curr_fifc_ordered_comp $_fifc_ordered_comp
+
+set test_home (mktemp -d)
+set -gx HOME "$test_home"
+mkdir -p "$HOME/downloads"
+
+set test_fzf_argv_path (mktemp)
+set test_fifc_token '~/downloads/'
+
+function commandline
+    switch $argv[1]
+        case --current-token
+            echo $test_fifc_token
+        case --cut-at-cursor
+            echo "ls $test_fifc_token"
+        case -b
+            echo "ls $test_fifc_token"
+        case --replace --function
+            return 0
+    end
+end
+
+function complete
+end
+
+function fd
+    if test "$argv[1]" = --version
+        echo "fd 8.3.0"
+    else
+        echo "$HOME/downloads/file.txt"
+    end
+end
+
+function fzf
+    printf '%s\n' $argv >$test_fzf_argv_path
+end
+
+set fifc_rm_cmd rm
+set _fifc_ordered_comp
+set comp_1 true '' '' '' _fifc_source_files
+set _fifc_unordered_comp comp_1
+
+_fifc
+
+set args (cat $test_fzf_argv_path)
+set query_index (contains --index -- --query $args)
+set actual $args[(math $query_index + 1)]
+
+@test "fifc keeps tilde fzf query" "$actual" = '~/downloads/'
+
+command rm -rf "$test_home"
+command rm $test_fzf_argv_path
+set -gx HOME "$curr_home"
+set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
+set -gx _fifc_ordered_comp $curr_fifc_ordered_comp
+functions --erase fd

--- a/tests/test_source_files_tilde.fish
+++ b/tests/test_source_files_tilde.fish
@@ -1,0 +1,65 @@
+set curr_home $HOME
+set curr_fifc_token $fifc_token
+set curr_fifc_query $fifc_query
+
+set test_home (mktemp -d)
+set -gx HOME "$test_home"
+mkdir -p "$HOME/downloads"
+
+function fd
+    if test "$argv[1]" = --version
+        echo "fd 8.3.0"
+    else
+        echo "$HOME/downloads/file.txt"
+    end
+end
+
+set fifc_token '~/downloads/'
+set fifc_query '~/downloads/'
+
+set actual (eval (_fifc_source_files))
+
+@test "source files fd preserves tilde prefix" "$actual" = '~/downloads/file.txt'
+
+command rm -rf "$test_home"
+set -gx HOME "$curr_home"
+set fifc_token $curr_fifc_token
+set fifc_query $curr_fifc_query
+functions --erase fd
+
+set curr_home $HOME
+set curr_path $PATH
+set curr_fifc_token $fifc_token
+set curr_fifc_query $fifc_query
+
+set test_home (mktemp -d)
+set -gx HOME "$test_home"
+mkdir -p "$HOME/downloads"
+
+functions --erase fd
+set PATH
+
+function find
+    echo "$HOME/downloads/file.txt"
+end
+
+function sed
+    while read -l line
+        echo $line
+    end
+end
+
+set fifc_token '~/downloads/'
+set fifc_query '~/downloads/'
+
+set actual (eval (_fifc_source_files))
+
+@test "source files find preserves tilde prefix" "$actual" = '~/downloads/file.txt'
+
+set PATH $curr_path
+command rm -rf "$test_home"
+set -gx HOME "$curr_home"
+set fifc_token $curr_fifc_token
+set fifc_query $curr_fifc_query
+functions --erase find
+functions --erase sed

--- a/tests/test_tilde_candidate.fish
+++ b/tests/test_tilde_candidate.fish
@@ -1,0 +1,24 @@
+set curr_home $HOME
+set curr_fifc_unordered_comp $_fifc_unordered_comp
+set curr_fifc_ordered_comp $_fifc_ordered_comp
+
+set test_home (mktemp -d)
+set -gx HOME "$test_home"
+mkdir -p "$HOME/downloads"
+echo "preview works" >"$HOME/downloads/file.txt"
+
+set _fifc_complist_path (mktemp)
+set fifc_commandline "cat ~/downloads/"
+set _fifc_ordered_comp
+set comp_1 'test -f "$fifc_candidate"' '.*' 'cat "$fifc_candidate"'
+set _fifc_unordered_comp comp_1
+
+set actual (_fifc_action preview '~/downloads/file.txt')
+
+@test "preview works with tilde candidate" "$actual" = "preview works"
+
+command rm -rf "$test_home"
+command rm $_fifc_complist_path
+set -gx HOME "$curr_home"
+set -gx _fifc_unordered_comp $curr_fifc_unordered_comp
+set -gx _fifc_ordered_comp $curr_fifc_ordered_comp


### PR DESCRIPTION
When completing paths starting with `~`, several issues occur due to fish not expanding `~` inside variables/command substitutions. So I fixed all the issues that I could find.

- Improved `~` expansion to only expand bare `~` and `~/...`, avoiding incorrect expansion of paths like `~dir/...`.
- Preventes trailing spaces after completing directories with `~`, e.g. `~/downloads/`.
- Preserves `~` in fzf suggestions instead of showing full `/home/user/...` paths.
- Escapes spaces in `~` paths with backslashes instead of generating quoted paths like `~'/path with spaces'`.
- Keep the fzf query for `~` paths so highlighting works for `~/...` completions.
- Expands `~` candidates before preview rule evaluation, so previews work for `~/...` files and directories.

Also added tests for each fix.

With all the fixes, I think completing paths with `~` works the same way as paths without `~`.